### PR TITLE
Workflow install step hotfix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - name: Build website
         run: npm run build
 


### PR DESCRIPTION
Temporarily update workflow to use `npm ci --legacy-peer-deps`.